### PR TITLE
Set image max-width to 800px

### DIFF
--- a/comic.pm
+++ b/comic.pm
@@ -127,7 +127,7 @@ sub compose_mail {
 	<meta name="qrichtext" content="1" />
 	<style>
 	b { color: #79965f; font-size: 11pt; font-family: Verdana, Arial, Helvetica; font-weight: bold; display: block; padding-left: 6px; }
-	blockquote img { border: 1px outset black; display: block; }
+	blockquote img { border: 1px outset black; display: block; max-width: 800px; }
 	blockquote { background-color: white; width: 600px; border: 12px solid white; }
 	</style>
 	</head>


### PR DESCRIPTION
This is to avoid rendering problems with Postimees comics on mobile devices.
Apparently Postimees likes super-sharp images with comics of at LEAST 2000 px width.

TODO: remove Postimees && get english Dilbert?