### PR TITLE
Fix last char detect

### DIFF
--- a/src/scrapers/TurnoffScraper.ts
+++ b/src/scrapers/TurnoffScraper.ts
@@ -28,7 +28,7 @@ export class TurnoffScraper implements ScraperInterface {
     }
 
     // https://github.com/oven-sh/bun/issues/8599
-    if (link[-1] !== "/") {
+    if (link[link.length - 1] !== "/") {
       link += "/";
     }
 


### PR DESCRIPTION
Fix for https://github.com/oven-sh/bun/issues/8599

apparently `string[-1]` doesn't work for bun. It's not Python.