### PR TITLE
Refactor: Use alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN bun test
 FROM base AS release
 # Run the app
 USER bun
-EXPOSE 3000/tcp
 ENTRYPOINT [ "bun", "run", "start" ]
 
 COPY --from=install /runtime/node_modules node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # Use the official Bun image
 # See all versions at https://hub.docker.com/r/oven/bun/tags
-FROM oven/bun:1 AS base
+FROM oven/bun:1-alpine AS base
 WORKDIR /app
 
 # Install dependencies into temp directory


### PR DESCRIPTION
To reduce image size

Base image sizes:

```
oven/bun              1                      72f3a81c4661   2 weeks ago      210MB
oven/bun              1-alpine               fd14048fe0b7   2 weeks ago      108MB
```

requires musl base image:
- [x] https://github.com/oven-sh/bun/pull/15241